### PR TITLE
CI: 'sudo: true' is no longer needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ matrix:
         - python: 3.7
           env: TOXENV=py37
           dist: xenial
-          sudo: true
         - python: pypy3
           env: TOXENV=pypy3
 


### PR DESCRIPTION
See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration